### PR TITLE
Moved pwsh upgrade to the end of the list

### DIFF
--- a/bicep-bootstrap/Install-BicepToolsForWindows.ps1
+++ b/bicep-bootstrap/Install-BicepToolsForWindows.ps1
@@ -14,10 +14,6 @@ New-Item -ItemType "file" $scriptPath -Force | Out-String | Write-Verbose
 
 $tools = @(
   @{
-    name = "PowerShell"
-    script = "Update-PowerShell.ps1"
-  },
-  @{
     name = "Git"
     script = "Install-GitForWindows.ps1"
   },
@@ -50,6 +46,10 @@ $tools = @(
     additionalArguments = @(
       "-moduleName Az.Resources"
     )
+  },
+  @{
+    name = "PowerShell"
+    script = "Update-PowerShell.ps1"
   }
 )
 


### PR DESCRIPTION
Moving the step to upgrade pwsh to the end of the list. This is a quick-fix so the script does not need to be executed twice.